### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,8 @@ Testnets for [Regen Ledger](https://github.com/regen-network/regen-ledger)
 
 ## Active Testnets
 
-### Regen Network Testnet 3000: COSMWASM Kontraŭa Testnet
-
-**Focus**: Adversarial testnet and network load testing with Regen Ledger running CosmWASM. This testnet may also morph into a Game of Zones testnet, as we are sensitive to the larger community opportunity.
-
-* Testnet schedule: 13th March - 24th Apr, 2020 (6 weeks)
-* Total points to be allocated: 1100+
-* Gentx submissions: 9th March 1500UTC (start date) - 12th March 0900 UTC (end date)
-* Genesis release time: 12th March, 1600UTC (23 hours before genesis time)
-* Network start time: 13th March, 1500UTC
-
-#### [Click here to join the testnet](./kontraua/README.md)
+We are currently supporting the BigBang1 Stargate testnet 
+###
 
 
 ## Upcoming Testnets
@@ -27,11 +18,23 @@ Here are the details for upcoming testnets. Please check our blog post [Regen Ne
 
 *Estimated Dates: April 4th week*
 
-*Total points to be allocated: 800*
+*Total points to be allocated: 1800*
 
 ## Historic Testnets (not in use)
 
 The testnets listed below are no longer active but are retained here for posterity. Do not waste your time trying to join them :)
+
+### Regen Network Testnet 3000: COSMWASM Kontraŭa Testnet
+
+**Focus**: Adversarial testnet and network load testing with Regen Ledger running CosmWASM. This testnet may also morph into a Game of Zones testnet, as we are sensitive to the larger community opportunity.
+
+* Testnet schedule: 13th March - 24th Apr, 2020 (6 weeks)
+* Total points to be allocated: 1100+
+* Gentx submissions: 9th March 1500UTC (start date) - 12th March 0900 UTC (end date)
+* Genesis release time: 12th March, 1600UTC (23 hours before genesis time)
+* Network start time: 13th March, 1500UTC
+
+#### [Click here to join the testnet](./kontraua/README.md)
 
 ### [`Algradigon-1`](https://github.com/regen-network/testnets/tree/modifications/archive/algradigon-1)
 


### PR DESCRIPTION
Moved ### Regen Network Testnet 3000: COSMWASM Kontraŭa Testnet to historical.  I also updated the medium post to more accurately reflect the future dates we are forseeing for the Regen Network Testnet 4000: Aplikiĝo Testnet.  I also mentioned the bigbang testnet, although no link is currently available.