### PR TITLE
Fix validator instructions for devnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here are the instructions to run a validator for `regen-devnet-1`:
 
 ```sh
 git clone https://github.com/regen-network/testnets
-cd regen-ledger
+cd testnets
 
 chmod +x scripts/devnet-val-setup.sh
 ./scripts/devnet-val-setup.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Persistent Peer: `4763e95d731a3402c1f06fbac1535fc38a2e439f@18.220.101.192:26656`
 Here are the instructions to run a validator for `regen-devnet-1`:
 
 ```sh
-git clone https://github.com/regen-network/regen-ledger
+git clone https://github.com/regen-network/testnets
 cd regen-ledger
 
 chmod +x scripts/devnet-val-setup.sh


### PR DESCRIPTION
The `scripts/devnet-val-setup.sh` script is in the testnets repo, but instructions were linking to clone regen ledger. This fixes that issue.