### PR TITLE
changed environment settings from .bashrc to .profile

### DIFF
--- a/scripts/devnet-val-setup.sh
+++ b/scripts/devnet-val-setup.sh
@@ -15,14 +15,14 @@ else
   tar -xvf go1.15.2.linux-amd64.tar.gz
   sudo mv go /usr/local
 
-  echo "" >> ~/.bashrc
-  echo 'export GOPATH=$HOME/go' >> ~/.bashrc
-  echo 'export GOROOT=/usr/local/go' >> ~/.bashrc
-  echo 'export GOBIN=$GOPATH/bin' >> ~/.bashrc
-  echo 'export PATH=$PATH:/usr/local/go/bin:$GOBIN' >> ~/.bashrc
+  echo "" >> ~/.profile
+  echo 'export GOPATH=$HOME/go' >> ~/.profile
+  echo 'export GOROOT=/usr/local/go' >> ~/.profile
+  echo 'export GOBIN=$GOPATH/bin' >> ~/.profile
+  echo 'export PATH=$PATH:/usr/local/go/bin:$GOBIN' >> ~/.profile
 
-  #source ~/.bashrc
-  . ~/.bashrc
+  #source ~/.profile
+  . ~/.profile
 
   go version
 fi


### PR DESCRIPTION
The script didn't set up Go correctly in some cases because it set Go paths in `~/.bashrc`, and that file isn't sourced on login shells [1]. Therefore, for anyone logging in via SSH to a server and running this script from that login shell, it didn't work. Changing to `~/.profile` works correctly.

[1] https://wiki.debian.org/EnvironmentVariables