### PR TITLE
change from go get to git clone to avoid error message

### DIFF
--- a/scripts/devnet-val-setup.sh
+++ b/scripts/devnet-val-setup.sh
@@ -40,7 +40,7 @@ CHAIN_ID=regen-devnet-3
 PERSISTENT_PEERS="55cf919bafebb627f3f7717de24c35c86df4f260@18.220.101.192:26656"
 
 echo "install regen-ledger"
-go get github.com/regen-network/regen-ledger
+git clone https://github.com/regen-network/regen-ledger $GOPATH/src/github.com/regen-network/regen-ledger
 cd $GOPATH/src/github.com/regen-network/regen-ledger
 git fetch
 git checkout v0.6.0-alpha4


### PR DESCRIPTION
The script used `go get` to clone the `regen-ledger` repo, but this resulted in an error saying that there are no Go files in the project, because `go get` tries to build things it gets (or something like that). Later in the same script, `git clone` is used for `cosmos-sdk`. In order to avoid that Go error and to have more consistency in the script, I changed the cloning of `regen-ledger` to `git clone`.