### PR TITLE
add a pause and prompt to copy the mnemonic recovery phrase

### DIFF
--- a/scripts/devnet-val-setup.sh
+++ b/scripts/devnet-val-setup.sh
@@ -49,6 +49,12 @@ make install
 echo "Creating keys"
 $DAEMON keys add $YOUR_KEY_NAME
 
+echo ""
+echo "After you have copied the mnemonic phrase in a safe place,"
+echo "press the space bar to continue."
+read -s -d ' '
+echo ""
+
 echo "Setting up your validator"
 $DAEMON init --chain-id $CHAIN_ID $YOUR_NAME
 curl http://18.220.101.192:26657/genesis | jq .result.genesis > ~/.regen/config/genesis.json


### PR DESCRIPTION
This pauses the script after generating keys and a mnemonic phrase for key recovery, and requires the user to press the space bar before continuing. Why? The first time I ran this script, I didn't even see the mnemonic phrase, since the script never paused and the text just kept running on the screen, and I didn't know I needed to go back and examine the whole thing. With this pause, users will be alerted to this important recovery mechanism. The only problem I can imagine is maybe a user imports keys they already have, and therefore there won't be any mnemonic displayed. They'll just press space to continue.