### PR TITLE
correct branch name in script info

### DIFF
--- a/scripts/gen_val_keys.sh
+++ b/scripts/gen_val_keys.sh
@@ -38,7 +38,7 @@ DENOM=utree
 CHAIN_ID=regen-testnet
 PERSISTENT_PEERS="f864b879f59141d0ad3828ee17ea0644bdd10e9b@18.220.101.192:26656"
 
-echo "install regen-ledger:master"
+echo "install regen-ledger:v0.6.0-alpha2"
 git clone https://github.com/regen-network/regen-ledger $GOPATH/src/github.com/regen-network/regen-ledger
 cd $GOPATH/src/github.com/regen-network/regen-ledger
 git checkout v0.6.0-alpha2


### PR DESCRIPTION
In `gen-val-key.sh`, the script told the user that the master branch of `regen-ledger` is being installed, but the script actually installs `v0.6.0-alpha2`. I corrected the information so that the user knows what branch is actually being installed. Maybe an even better way to do this would be to set a variable $BRANCH and use it for both the info and the clone command.