### PR TITLE
fix ExecStart command in regen.service

### DIFF
--- a/aplikigo-1/README.md
+++ b/aplikigo-1/README.md
@@ -193,7 +193,7 @@ Description=Regen Node
 After=network-online.target
 [Service]
 User=${USER}
-ExecStart=${GOBIN}/regen start
+ExecStart=$(which regen) start
 Restart=always
 RestartSec=3
 LimitNOFILE=4096


### PR DESCRIPTION
The ExecStart line in the regen.service file is incorrect (/regen) because the command in the README calls $GOBIN, but the jim380 go_install.sh recommnded in the README doesn't set $GOBIN (it only sets $GOPATH and $PATH).