### PR TITLE
add necessary flags

### DIFF
--- a/aplikigo-1/tasks/phase-1/3-gir-upgrade/INSTRUCTIONS.md
+++ b/aplikigo-1/tasks/phase-1/3-gir-upgrade/INSTRUCTIONS.md
@@ -2,15 +2,17 @@
 
 ## How to vote
 
-Here is the CLI command to vote on the proposal
-    ```sh
-    regen tx gov vote <proposalID> <option> --from <your_key_or_acc_address>
-    ```
-    ex:
+Here is the CLI command to vote on the proposal:
 
-    ```sh
-    regen tx gov vote 1 yes --from regen:1gpgpkmz3swt5ucdjxvrszk6yvjxjylsh4eur9d
-    ```
+
+    regen tx gov vote <proposalID> <option> --from <your_key_or_acc_address> [flags]
+
+
+Eg:
+
+``` 
+regen tx gov vote 3 yes --from <your_address> --gas auto -y --fees=2000utree --chain-id aplikigo-1
+```  
 
 
 ## How to upgrade


### PR DESCRIPTION
Seems like chain id is a necessary flag, some users reported error when chain-id or gas is not explicitly mentioned

Eg: People on discord

**1)**
```
root@vmi519033:~# regen tx gov vote 1 yes --from regen:1gr6t69vwxrj9x4djjc3katv8len3gf3d87q8p4
Enter keyring passphrase:
Error: chain ID required but not specified
```
Adding chain-id solved the problem

**2)**

`{"height":"0","txhash":"1AE4740E5995EB7A8FF3490B174B09A9EF5A7DD534F257CCBBC95C3EE57D73EF","codespace":"sdk","code":13,"data":"","raw_log":"insufficient fees; got:  required: 5000utree: insufficient fee","logs":[],"info":"","gas_wanted":"200000","gas_used":"0","tx":null,"timestamp":""}"`

Adding gas flag solved the problem

-------------------------------------------------
@anilCSE @glandua Please review :)