### PR TITLE
Use cosmovisor v1.0.0 in testnet-val-setup.sh

### DIFF
--- a/scripts/testnet-val-setup.sh
+++ b/scripts/testnet-val-setup.sh
@@ -70,7 +70,7 @@ echo "Installing cosmovisor - an upgrade manager..."
 rm -rf $GOPATH/src/github.com/cosmos/cosmos-sdk
 git clone https://github.com/cosmos/cosmos-sdk $GOPATH/src/github.com/cosmos/cosmos-sdk
 cd $GOPATH/src/github.com/cosmos/cosmos-sdk
-git checkout v0.40.0
+git checkout cosmovisor/v1.0.0
 cd cosmovisor
 make cosmovisor
 cp cosmovisor $GOBIN/cosmovisor
@@ -88,7 +88,7 @@ After=network-online.target
 [Service]
 Environment="DAEMON_NAME=regen"
 Environment="DAEMON_HOME=${HOME}/.${DAEMON}"
-Environment="DAEMON_RESTART_AFTER_UPGRADE=on"
+Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 User=${USER}
 ExecStart=${GOBIN}/cosmovisor start
 Restart=always


### PR DESCRIPTION
As documented in the current regen 1.0.0 validator instructions, cosmovisor v1.0.0 should be used: https://github.com/regen-network/regen-ledger/blob/05f483ab034c7d23b2094fcb6a379c5a867d0918/docs/getting-started/running-a-validator.md?plain=1#L163

Cosmovisor (unknown version?) from cosmos-sdk v0.40.0 did not work for the regen-redwood-1 2.0.0 upgrade. At the upgrade time an empty `.regen/data/upgrade-info.json` file was created. It seems that cosmovisor itself isn't responsible for creating this file so I'm not sure what happened... but this version of cosmovisor would have read stdout log messages to detect upgrades, so maybe it never halted correctly? https://github.com/cosmos/cosmos-sdk/tree/v0.40.0/cosmovisor

Anyways, not too worried about why it failed, as that was not the documented version to be using. After manually coping the upgrade info from the proposal into `upgrade-info.json` it continued on OK.

This all happened on a sentry node before the validator was upgraded. I was able to update the validator to cosmovisor v1.0.0 and the upgrade went smoothly. This also required changing the `DAEMON_RESTART_AFTER_UPGRADE` env to be a boolean `true`, not `on`.